### PR TITLE
Normalize login nicknames

### DIFF
--- a/app/routers/practice.py
+++ b/app/routers/practice.py
@@ -90,12 +90,19 @@ def _generate_problem(problem_id: int) -> GeneratedProblem:
 
 @router.post("/v1/login", response_model=LoginResponse)
 async def login(payload: LoginRequest, repository: UserRepository = Depends(_get_user_repository)) -> LoginResponse:
-    existing = repository.get_by_nickname(payload.nickname)
+    normalized_nickname = payload.nickname.strip()
+    if not normalized_nickname:
+        raise HTTPException(
+            status_code=status.HTTP_422_UNPROCESSABLE_ENTITY,
+            detail={"message": "닉네임을 입력해주세요."},
+        )
+
+    existing = repository.get_by_nickname(normalized_nickname)
     password_hash = _hash_password(payload.password)
 
     if existing is None:
         created = repository.create_user(
-            nickname=payload.nickname.strip(),
+            nickname=normalized_nickname,
             password_hash=password_hash,
             role="student",
         )

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -232,6 +232,27 @@ def test_login_creates_and_returns_user(client) -> None:
     assert payload["message"].startswith("새 계정")
 
 
+def test_login_trims_whitespace_and_reuses_account(client) -> None:
+    first = client.post(
+        "/api/v1/login",
+        json={"nickname": "  spaced-user  ", "password": "secret"},
+    )
+    assert first.status_code == 200
+    created = first.json()
+    assert created["nickname"] == "spaced-user"
+
+    second = client.post(
+        "/api/v1/login",
+        json={"nickname": "\t spaced-user\n", "password": "secret"},
+    )
+    assert second.status_code == 200
+    payload = second.json()
+
+    assert payload["user_id"] == created["user_id"]
+    assert payload["nickname"] == "spaced-user"
+    assert payload["message"] == "로그인 성공"
+
+
 def test_login_with_wrong_password_returns_error(client) -> None:
     success = client.post(
         "/api/v1/login",


### PR DESCRIPTION
## Summary
- trim login nicknames once, rejecting empty values
- reuse the normalized nickname for repository access and responses
- add an API regression test covering whitespace-trimmed logins

## Testing
- pytest tests/test_api.py::test_login_creates_and_returns_user tests/test_api.py::test_login_trims_whitespace_and_reuses_account

------
https://chatgpt.com/codex/tasks/task_e_68e3d7f530d8832bab5926b1552d4d80