### PR TITLE
Add Optional typing import to template engine

### DIFF
--- a/app/template_engine.py
+++ b/app/template_engine.py
@@ -9,7 +9,7 @@ import random
 from dataclasses import dataclass
 from pathlib import Path
 from threading import RLock
-from typing import Any, List, Mapping, MutableMapping, Sequence
+from typing import Any, List, Mapping, MutableMapping, Optional, Sequence
 
 from .config import get_settings
 


### PR DESCRIPTION
## Summary
- add Optional to the typing imports in `app/template_engine.py` to match `ParameterSpec` annotations

## Testing
- PYTHONPATH=. pytest tests/test_curriculum.py::test_list_concepts_returns_node


------
https://chatgpt.com/codex/tasks/task_e_68e3e343990c832bbd3b1436ac566b11