### PR TITLE
Update frontend attempt submission to new endpoint

### DIFF
--- a/frontend/src/types/index.ts
+++ b/frontend/src/types/index.ts
@@ -74,13 +74,14 @@ export type APISession = {
   problems: APIProblem[];
 };
 
-export type APIProblemResponse = {
-  problem_id: number;
-  chosen_answer: number;
+export type ProblemAttemptResponse = {
+  attempt_id: number;
+  problem_id: string;
+  category: string;
+  submitted_answer: number;
   correct_answer: number;
   is_correct: boolean;
-  attempt_no: number;
-  message: string;
+  attempted_at: string;
 };
 
 export type MathProblem = {

--- a/frontend/src/utils/api.ts
+++ b/frontend/src/utils/api.ts
@@ -1,9 +1,9 @@
 import type {
-  APIProblemResponse,
   APISession,
   CurriculumConcept,
   GeneratedItem,
   LRCEvaluation,
+  ProblemAttemptResponse,
   TemplateSummary
 } from '../types';
 
@@ -35,15 +35,13 @@ export async function createSession(): Promise<APISession> {
 
 // 문제 답안 제출
 export async function submitAnswer(
-  problemId: number, 
-  chosenAnswer: number, 
-  attemptNo: number = 1
-): Promise<APIProblemResponse> {
-  return apiCall<APIProblemResponse>(`/v1/problems/${problemId}`, {
-    method: 'PATCH',
+  problemId: string | number,
+  chosenAnswer: number
+): Promise<ProblemAttemptResponse> {
+  return apiCall<ProblemAttemptResponse>(`/problems/${problemId}/attempts`, {
+    method: 'POST',
     body: JSON.stringify({
-      chosen_answer: chosenAnswer,
-      attempt_no: attemptNo,
+      answer: chosenAnswer,
     }),
   });
 }


### PR DESCRIPTION
## Summary
- update the submitAnswer helper to use the new attempts endpoint and payload
- align the ProblemAttemptResponse type with the FastAPI ProblemAttemptResponse schema

## Testing
- npm run build
- pytest tests/test_api.py::test_submit_correct_attempt_records_success

------
https://chatgpt.com/codex/tasks/task_e_68e4ab048138832bb56b766c89489903