### PR TITLE
Format typing import for template engine

### DIFF
--- a/app/template_engine.py
+++ b/app/template_engine.py
@@ -9,7 +9,14 @@ import random
 from dataclasses import dataclass
 from pathlib import Path
 from threading import RLock
-from typing import Any, List, Mapping, MutableMapping, Optional, Sequence
+from typing import (
+    Any,
+    List,
+    Mapping,
+    MutableMapping,
+    Optional,
+    Sequence,
+)
 
 from .config import get_settings
 


### PR DESCRIPTION
## Summary
- format the typing import block to explicitly include Optional for template engine

## Testing
- PYTHONPATH=. pytest tests/test_curriculum.py::test_list_concepts_returns_node

------
https://chatgpt.com/codex/tasks/task_e_68e4ab116ed8832ba4e3285ccdcfd257